### PR TITLE
fix typos in POD that broke links on CPAN

### DIFF
--- a/lib/Catalyst/Model/HTMLFormhandler.pm
+++ b/lib/Catalyst/Model/HTMLFormhandler.pm
@@ -200,7 +200,7 @@ __PACKAGE__->meta->make_immutable;
 
 =head1 NAME
 
-Catalyst::Model::HTMLFormhandler - Proxy a directory of HTML::Formhandler forms
+Catalyst::Model::HTMLFormhandler - Proxy a directory of HTML::FormHandler forms
 
 =head1 SYNOPSIS
 
@@ -224,7 +224,7 @@ And then using it in a controller:
 
 =head1 DESCRIPTION
 
-Assuming a project namespace 'MyApp::Form' with L<HTML::Formhandler> forms. like
+Assuming a project namespace 'MyApp::Form' with L<HTML::FormHandler> forms. like
 the following example:
 
   package MyApp::Form::Email;
@@ -365,7 +365,7 @@ John Napiorkowski L<email:jjnapiork@cpan.org>
   
 =head1 SEE ALSO
  
-L<Catalyst>, L<Catalyst::Model>, L<HTML::Formhandler>, L<Module::Pluggable>
+L<Catalyst>, L<Catalyst::Model>, L<HTML::FormHandler>, L<Module::Pluggable>
 
 =head1 COPYRIGHT & LICENSE
  


### PR DESCRIPTION
The naming of your module is unlucky, because the thing is called HTML::FormHandler with a capital H. All over the code that is correct, but in the POD it was called HTML::Formhandler with a small h, which broke the hyperlinks on CPAN.